### PR TITLE
Add method for sorting hashes

### DIFF
--- a/lib/abstractivator/sort.rb
+++ b/lib/abstractivator/sort.rb
@@ -1,0 +1,16 @@
+module Abstractivator
+  module Sort
+    def deep_sort_hash(obj)
+      case obj
+      when Hash
+        obj.sort.to_h.each_with_object({}) do |(k, v), a|
+          a[k] = deep_sort_hash(v)
+        end
+      when Array
+        obj.map(&method(:deep_sort_hash))
+      else
+        obj
+      end
+    end
+  end
+end

--- a/spec/lib/abstractivator/sort_spec.rb
+++ b/spec/lib/abstractivator/sort_spec.rb
@@ -1,0 +1,54 @@
+require 'abstractivator/sort'
+
+describe Abstractivator::Sort do
+  include Abstractivator::Sort
+  describe '#deep_sort_hash' do
+    context 'when empty hash' do
+      let(:hash) { {} }
+      it 'returns empty hash' do
+        expect_same_order(deep_sort, {})
+      end
+    end
+
+    context 'when single level' do
+      let(:hash) { {one: 1, two: '2', three: 3, four: '4'} }
+      it 'returns new hash with the keys sorted alpha-numerically' do
+        expected = {four: '4', one: 1, three: 3, two: '2'}
+        expect_same_order(deep_sort, expected)
+      end
+    end
+
+    context 'when mult-level hash' do
+      let(:hash) { {one: 1, two: {three: {four: '4', five: 5}}, six: 6} }
+      it 'returns new hash with the keys sorted alpha-numerically' do
+        expected = {one: 1, six: 6, two: {three: {five: 5, four: '4'}}}
+        expect_same_order(deep_sort, expected)
+      end
+    end
+
+    context 'when contains an array' do
+      let(:hash) { {one: 1, two: [{three: {four: '4', five: 5}}, 'six', :seven], eight: 8} }
+      it 'returns new hash with the keys sorted alpha-numerically (does not sort arrays)' do
+        expected = {eight: 8, one: 1, two: [{three: {five: 5, four: '4'}}, 'six', :seven]}
+        expect_same_order(deep_sort, expected)
+      end
+    end
+
+    def deep_sort
+      deep_sort_hash(hash)
+    end
+
+    def expect_same_order(actual, expected)
+      case actual
+      when Hash
+        expect(actual.keys).to eql expected.keys
+        expect_same_order(actual.values, expected.values)
+      when Array
+        expect(actual.size).to eql expected.size
+        actual.zip(expected).each { |a, e| expect_same_order(a, e) }
+      else
+        expect(actual).to eql expected
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is used for display purposes when comparing hash expectations.