### PR TITLE
Improve outer_join performance

### DIFF
--- a/lib/abstractivator/enumerable_ext.rb
+++ b/lib/abstractivator/enumerable_ext.rb
@@ -9,8 +9,8 @@ module Enumerable
   # returns an array of 2-element arrays, each of which is a left/right pair.
   def self.outer_join(left, right, get_left_key, get_right_key, left_default, right_default)
 
-    ls = left.hash_map(get_left_key)
-    rs = right.hash_map(get_right_key)
+    ls = left.inject({}) { |h, x| h.store(get_left_key.call(x), x); h }   # Avoid #hash_map and Array#to_h
+    rs = right.inject({}) { |h, x| h.store(get_right_key.call(x), x); h } #   for better performance
 
     raise 'duplicate left keys' if ls.size < left.size
     raise 'duplicate right keys' if rs.size < right.size


### PR DESCRIPTION
Please scrutinize the optimization. Can you think of any unintended consequences of setting the Proc instance variable?

An advantage of this approach is that the cached values are automatically garbage collected when the associated Proc is collected.

An alternative approach is to use a hash cache. That avoids mutating the procs, but there is no good time to invalidate the cache, so it grows without bound. (It also turns out to be slower.)