### PR TITLE
Fixed value_map nil weirdness

### DIFF
--- a/lib/abstractivator/value_map.rb
+++ b/lib/abstractivator/value_map.rb
@@ -1,14 +1,11 @@
-# like Enumerable#map, except if the receiver is not enumerable,
+# Like Enumerable#map, except if the receiver is not enumerable,
 # i.e., a single value, then it transforms the single value.
+#
+# [2,3].value_map { |x| x * x }  =>  [4, 9]
+# 2    .value_map { |x| x * x }  =>  4
 
 class Array
   alias_method :value_map, :map
-end
-
-class NilClass
-  def value_map
-    nil
-  end
 end
 
 class Object

--- a/spec/lib/abstractivator/value_map_spec.rb
+++ b/spec/lib/abstractivator/value_map_spec.rb
@@ -22,7 +22,7 @@ describe '#value_map' do
   end
 
   it 'maps nil' do
-    expect(nil.value_map(&method(:square))).to be nil
+    expect(nil.value_map(&:to_s)).to eql ''
   end
 
   def square(x)


### PR DESCRIPTION
Nothing in web uses `value_map` (except the new entity code), so this change shouldn't break anything.